### PR TITLE
call render directly within each individual test

### DIFF
--- a/src/tests/Counter.test.js
+++ b/src/tests/Counter.test.js
@@ -4,25 +4,23 @@ import "@testing-library/jest-dom";
 // import the Counter component here
 import Counter from "../components/Counter";
 
-beforeEach(() => {
-  // Render the Counter component here
-  render(<Counter />);
-});
-
 test("renders counter message", () => {
   // Complete the unit test below based on the objective in the line above
+  render(<Counter />);
   const header = screen.getByText(/Counter/i);
   expect(header).toBeInTheDocument();
 });
 
 test("should render initial count with value of 0", () => {
   // Complete the unit test below based on the objective in the line above
+  render(<Counter />);
   const countElement = screen.getByTestId("count");
   expect(countElement).toHaveTextContent("0");
 });
 
 test("clicking + increments the count", () => {
   // Complete the unit test below based on the objective in the line above
+  render(<Counter />);
   const incrementButton = screen.getByText("+");
   fireEvent.click(incrementButton);
 
@@ -33,6 +31,7 @@ test("clicking + increments the count", () => {
 
 test("clicking - decrements the count", () => {
   // Complete the unit test below based on the objective in the line above
+  render(<Counter />);
   const decrementButton = screen.getByText("-");
   fireEvent.click(decrementButton);
 


### PR DESCRIPTION
Added `render(<Counter />);` directly in each test for isolated component rendering

- Removed `beforeEach` block for rendering
- Added `render(<Counter />);` directly in each test for isolated component rendering